### PR TITLE
Add caching to op-supervisor L1 accessor

### DIFF
--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -12,10 +12,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 )
 
 const reqTimeout = time.Second * 10
+
+const cacheSize = 100
 
 var errNoL1Source = errors.New("no L1 source configured")
 
@@ -49,6 +52,13 @@ type L1Accessor struct {
 
 	// to interrupt requests, so the system can shut down quickly
 	sysCtx context.Context
+
+	// cache of recently fetched L1 block references
+	cache *caching.LRUCache[uint64, eth.L1BlockRef]
+}
+
+func (p *L1Accessor) resetCache() {
+	p.cache = caching.NewLRUCache[uint64, eth.L1BlockRef](nil, "l1blockrefs", cacheSize)
 }
 
 var _ event.AttachEmitter = (*L1Accessor)(nil)
@@ -60,6 +70,7 @@ func NewL1Accessor(sysCtx context.Context, log log.Logger, client L1Source) *L1A
 		// placeholder confirmation depth
 		confDepth: 2,
 		sysCtx:    sysCtx,
+		cache:     caching.NewLRUCache[uint64, eth.L1BlockRef](nil, "l1blockrefs", cacheSize),
 	}
 }
 
@@ -86,6 +97,7 @@ func (p *L1Accessor) AttachClient(client L1Source, subscribe bool) {
 	p.UnsubscribeLatestHandler()
 
 	p.client = client
+	p.resetCache()
 
 	if client != nil && subscribe {
 		p.SubscribeLatestHandler()
@@ -185,6 +197,8 @@ func (p *L1Accessor) onLatest(ctx context.Context, ref eth.L1BlockRef) {
 			IncomingBlock: ref.ID(),
 		})
 		p.log.Info("Reorg detected", "ref", ref)
+		// clear cached block references to avoid serving stale data
+		p.resetCache()
 	}
 
 	// Update the tip
@@ -202,5 +216,12 @@ func (p *L1Accessor) L1BlockRefByNumber(ctx context.Context, number uint64) (eth
 	if number > p.tip.Number-p.confDepth {
 		return eth.L1BlockRef{}, ethereum.NotFound
 	}
-	return p.client.L1BlockRefByNumber(ctx, number)
+	if ref, ok := p.cache.Get(number); ok {
+		return ref, nil
+	}
+	ref, err := p.client.L1BlockRefByNumber(ctx, number)
+	if err == nil {
+		p.cache.Add(number, ref)
+	}
+	return ref, err
 }

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor_test.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type mockL1Source struct {
@@ -58,4 +59,39 @@ func TestL1Accessor(t *testing.T) {
 	accessor.AttachClient(source2, false)
 	require.Equal(t, source2, accessor.client)
 
+}
+
+// TestL1AccessorCaching verifies that repeated requests for the same block
+// number hit the cache instead of the underlying source and that the cache is
+// cleared on reorg events.
+func TestL1AccessorCaching(t *testing.T) {
+	log := testlog.Logger(t, slog.LevelDebug)
+	calls := 0
+	source := &mockL1Source{}
+	source.l1BlockRefByNumberFn = func(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+		calls++
+		return eth.L1BlockRef{Number: number}, nil
+	}
+
+	accessor := NewL1Accessor(context.Background(), log, source)
+	accessor.tip = eth.BlockID{Hash: common.Hash{0xaa}, Number: 20}
+
+	// first call should query the source
+	_, err := accessor.L1BlockRefByNumber(context.Background(), 5)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+
+	// second call should be served from cache
+	_, err = accessor.L1BlockRefByNumber(context.Background(), 5)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+
+	// trigger a reorg to clear the cache
+	accessor.tip = eth.BlockID{Hash: common.Hash{0xbb}, Number: 20}
+	accessor.onLatest(context.Background(), eth.L1BlockRef{Number: 21, ParentHash: common.Hash{0xcc}, Hash: common.Hash{0xdd}})
+
+	// cached value should be gone, expect another call to source
+	_, err = accessor.L1BlockRefByNumber(context.Background(), 5)
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
 }


### PR DESCRIPTION
## Summary
- add a small LRU cache for L1 block references in the supervisor's L1 accessor
- reset the cache when attaching a new client or on reorg
- test L1 block caching behaviour

## Testing
- `go test ./op-supervisor/supervisor/backend/l1access -run TestL1Accessor -run TestL1AccessorCaching` *(fails: no route to host)*