### PR TITLE
Rename managed mode references to indexing mode

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestL2CLAheadOfSupervisor tests the below scenario:
-// L2CL ahead of supervisor, aka supervisor needs to reset the L2CL, to reproduce old data. Currently supervisor has only managed mode implemented, so the supervisor will ask the L2CL to reset back.
+// L2CL ahead of supervisor, aka supervisor needs to reset the L2CL, to reproduce old data. Currently supervisor has only indexing mode implemented, so the supervisor will ask the L2CL to reset back.
 func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	t := devtest.SerialT(gt)
 
@@ -21,7 +21,7 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 
 	// Make sequencers (L2CL), verifiers (L2CL), and supervisors sync for a few blocks.
 	// Sequencer and verifier are connected via P2P, which makes their unsafe heads in sync.
-	// Both L2CLs are in managed mode, digesting L1 blocks from the supervisor and reporting unsafe and safe blocks back to the supervisor.
+	// Both L2CLs are in indexing mode, digesting L1 blocks from the supervisor and reporting unsafe and safe blocks back to the supervisor.
 	delta := uint64(10)
 	logger.Info("Make sure verifiers advances unsafe head", "delta", delta)
 	dsl.CheckAll(t,

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -123,7 +123,7 @@ func (n *L2CLNode) Stop() {
 	n.opNode = nil
 }
 
-func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
 
@@ -192,10 +192,9 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l
 			require.NoError(err, "failed to load p2p config")
 		}
 
-		// specify interop config, but do not configure anything, to disable managed mode
+		// specify interop config, but do not configure anything, to disable indexing mode
 		interopCfg := &interop.Config{}
-
-		if managedMode {
+		if indexingMode {
 			interopCfg = &interop.Config{
 				RPCAddr: "127.0.0.1",
 				// When L2CL starts, store its RPC port here

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -90,7 +90,7 @@ type L2Verifier struct {
 
 type L2API interface {
 	engine.Engine
-	managed.L2Source
+       indexing.L2Source
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 	// GetProof returns a proof of the account, it may return a nil result without error if the address was not found.

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -130,7 +130,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 
 	var interopSys interop.SubSystem
 	if cfg.InteropTime != nil {
-		interopSys = managed.NewManagedMode(log, cfg, "127.0.0.1", 0, interopJWTSecret, l1, eng, &opmetrics.NoopRPCMetrics{})
+		interopSys = indexing.NewIndexingMode(log, cfg, "127.0.0.1", 0, interopJWTSecret, l1, eng, &opmetrics.NoopRPCMetrics{})
 		sys.Register("interop", interopSys, opts)
 		require.NoError(t, interopSys.Start(context.Background()))
 		t.Cleanup(func() {
@@ -159,8 +159,8 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, ctx, eng), opts)
 
-	managedMode := interopSys != nil
-	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, managedMode)
+	indexingMode := interopSys != nil
+	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, indexingMode)
 	sys.Register("pipeline", derive.NewPipelineDeriver(ctx, pipeline), opts)
 
 	testActionEmitter := sys.Register("test-action", nil, opts)
@@ -179,7 +179,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		L2:             eng,
 		Log:            log,
 		Ctx:            ctx,
-		ManagedMode:    managedMode,
+		IndexingMode:   indexingMode,
 	}, opts)
 
 	sys.Register("engine", engine.NewEngDeriver(log, ctx, cfg, metrics, ec), opts)
@@ -234,8 +234,8 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 
 func (v *L2Verifier) InteropSyncNode(t Testing) syncnode.SyncNode {
 	require.NotNil(t, v.interopSys, "interop sub-system must be running")
-	m, ok := v.interopSys.(*managed.ManagedMode)
-	require.True(t, ok, "Interop sub-system must be in managed-mode if used as sync-node")
+	m, ok := v.interopSys.(*indexing.IndexingMode)
+	require.True(t, ok, "Interop sub-system must be in indexing-mode if used as sync-node")
 	auth := rpc.WithHTTPAuth(gnode.NewJWTAuth(m.JWTSecret()))
 	opts := []client.RPCOption{client.WithGethRPCOptions(auth)}
 	cl, err := client.CheckAndDial(t.Ctx(), v.log, m.WSEndpoint(), auth)

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -326,7 +326,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	replacementBlock, err := actors.ChainB.SequencerEngine.EthClient().BlockByHash(t.Ctx(), status.SafeL2.Hash)
 	require.NoError(t, err)
 	txs := replacementBlock.Transactions()
-	out, err := managed.DecodeInvalidatedBlockTx(txs[len(txs)-1])
+       out, err := indexing.DecodeInvalidatedBlockTx(txs[len(txs)-1])
 	require.NoError(t, err)
 	require.Equal(t, originalOutput.OutputRoot, eth.OutputRoot(out))
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -410,12 +410,12 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		return err
 	}
 
-	managedMode := false
+	indexingMode := false
 	sys, err := cfg.InteropConfig.Setup(ctx, n.log, &n.cfg.Rollup, n.l1Source, n.l2Source, n.metrics)
 	if err != nil {
 		return fmt.Errorf("failed to setup interop: %w", err)
 	} else if sys != nil { // we continue with legacy mode if no interop sub-system is set up.
-		_, managedMode = sys.(*managed.ManagedMode)
+		_, indexingMode = sys.(*indexing.IndexingMode)
 		n.interopSys = sys
 		n.eventSys.Register("interop", n.interopSys)
 	}
@@ -447,7 +447,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 	}
 
 	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, cfg.DependencySet, n.l2Source, n.l1Source,
-		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, managedMode)
+		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, indexingMode)
 	return nil
 }
 
@@ -781,7 +781,7 @@ func (n *OpNode) HTTPPort() (int, error) {
 }
 
 func (n *OpNode) InteropRPC() (rpcEndpoint string, jwtSecret eth.Bytes32) {
-	m, ok := n.interopSys.(*managed.ManagedMode)
+	m, ok := n.interopSys.(*indexing.IndexingMode)
 	if !ok {
 		return "", [32]byte{}
 	}
@@ -789,7 +789,7 @@ func (n *OpNode) InteropRPC() (rpcEndpoint string, jwtSecret eth.Bytes32) {
 }
 
 func (n *OpNode) InteropRPCPort() (int, error) {
-	m, ok := n.interopSys.(*managed.ManagedMode)
+	m, ok := n.interopSys.(*indexing.IndexingMode)
 	if !ok {
 		return 0, fmt.Errorf("failed to fetch interop port for op-node")
 	}

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -96,13 +96,13 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
 func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet DependencySet, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
-	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedMode bool,
+	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, indexingMode bool,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
 	// Stages are strung together into a pipeline,
 	// results are pulled from the stage closed to the L2 engine, which pulls from the previous stage, and so on.
 	var l1Traversal l1TraversalStage
-	if managedMode {
+	if indexingMode {
 		l1Traversal = NewL1TraversalManaged(log, rollupCfg, l1Fetcher)
 	} else {
 		l1Traversal = NewL1Traversal(log, rollupCfg, l1Fetcher)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -174,7 +174,7 @@ func NewDriver(
 	syncCfg *sync.Config,
 	sequencerConductor conductor.SequencerConductor,
 	altDA AltDAIface,
-	managedMode bool,
+	indexingMode bool,
 ) *Driver {
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 
@@ -207,7 +207,7 @@ func NewDriver(
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, driverCtx, l2))
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, indexingMode)
 
 	sys.Register("pipeline",
 		derive.NewPipelineDeriver(driverCtx, derivationPipeline))
@@ -223,7 +223,7 @@ func NewDriver(
 		L2:             l2,
 		Log:            log,
 		Ctx:            driverCtx,
-		ManagedMode:    managedMode,
+		IndexingMode:   indexingMode,
 	}
 	sys.Register("sync", syncDeriver)
 

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -225,7 +225,7 @@ type SyncDeriver struct {
 
 	// When in interop, and managed by an op-supervisor,
 	// the node performs a reset based on the instructions of the op-supervisor.
-	ManagedMode bool
+	IndexingMode bool
 }
 
 func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
@@ -339,9 +339,9 @@ func (s *SyncDeriver) onEngineConfirmedReset(x engine.EngineResetConfirmedEvent)
 }
 
 func (s *SyncDeriver) onResetEvent(x rollup.ResetEvent) {
-	if s.ManagedMode {
-		s.Log.Warn("Encountered reset in Managed Mode, waiting for op-supervisor", "err", x.Err)
-		// ManagedMode will pick up the ResetEvent
+	if s.IndexingMode {
+		s.Log.Warn("Encountered reset in Indexing Mode, waiting for op-supervisor", "err", x.Err)
+		// IndexingMode will pick up the ResetEvent
 		return
 	}
 	// If the system corrupts, e.g. due to a reorg, simply reset it
@@ -379,7 +379,7 @@ func (s *SyncDeriver) SyncStep() {
 
 	// If interop is configured, we have to run the engine events,
 	// to ensure cross-L2 safety is continuously verified against the interop-backend.
-	if s.Config.InteropTime != nil && !s.ManagedMode {
+	if s.Config.InteropTime != nil && !s.IndexingMode {
 		s.Emitter.Emit(engine.CrossUpdateRequestEvent{})
 	}
 }

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 )
@@ -43,5 +43,5 @@ func (cfg *Config) Setup(ctx context.Context, logger log.Logger, rollupCfg *roll
 	if err != nil {
 		return nil, err
 	}
-	return managed.NewManagedMode(logger, rollupCfg, cfg.RPCAddr, cfg.RPCPort, jwtSecret, l1, l2, m), nil
+	return indexing.NewIndexingMode(logger, rollupCfg, cfg.RPCAddr, cfg.RPCPort, jwtSecret, l1, l2, m), nil
 }

--- a/op-node/rollup/interop/iface.go
+++ b/op-node/rollup/interop/iface.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 )
 
@@ -18,14 +18,14 @@ type SubSystem interface {
 	Stop(ctx context.Context) error
 }
 
-var _ SubSystem = (*managed.ManagedMode)(nil)
+var _ SubSystem = (*indexing.IndexingMode)(nil)
 
 type L1Source interface {
-	managed.L1Source
+	indexing.L1Source
 }
 
 type L2Source interface {
-	managed.L2Source
+	indexing.L2Source
 }
 
 type Setup interface {

--- a/op-node/rollup/interop/indexing/api.go
+++ b/op-node/rollup/interop/indexing/api.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 )
 
 type InteropAPI struct {
-	backend *ManagedMode
+	backend *IndexingMode
 }
 
 func (ib *InteropAPI) PullEvent() (*supervisortypes.ManagedEvent, error) {

--- a/op-node/rollup/interop/indexing/attributes.go
+++ b/op-node/rollup/interop/indexing/attributes.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"errors"

--- a/op-node/rollup/interop/indexing/attributes_test.go
+++ b/op-node/rollup/interop/indexing/attributes_test.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"math/big"

--- a/op-node/rollup/interop/indexing/system.go
+++ b/op-node/rollup/interop/indexing/system.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"context"
@@ -38,9 +38,9 @@ type L1Source interface {
 	L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error)
 }
 
-// ManagedMode makes the op-node managed by an op-supervisor,
+// IndexingMode makes the op-node managed by an op-supervisor,
 // by serving sync work and updating the canonical chain based on instructions.
-type ManagedMode struct {
+type IndexingMode struct {
 	log log.Logger
 
 	emitter event.Emitter
@@ -56,9 +56,9 @@ type ManagedMode struct {
 	jwtSecret eth.Bytes32
 }
 
-func NewManagedMode(log log.Logger, cfg *rollup.Config, addr string, port int, jwtSecret eth.Bytes32, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) *ManagedMode {
-	log = log.With("mode", "managed", "chainId", cfg.L2ChainID)
-	out := &ManagedMode{
+func NewIndexingMode(log log.Logger, cfg *rollup.Config, addr string, port int, jwtSecret eth.Bytes32, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) *IndexingMode {
+	log = log.With("mode", "indexing", "chainId", cfg.L2ChainID)
+	out := &IndexingMode{
 		log:       log,
 		cfg:       cfg,
 		l1:        l1,
@@ -71,7 +71,7 @@ func NewManagedMode(log log.Logger, cfg *rollup.Config, addr string, port int, j
 		rpc.WithWebsocketEnabled(),
 		rpc.WithLogger(log),
 		rpc.WithJWTSecret(jwtSecret[:]),
-		rpc.WithRPCRecorder(m.NewRecorder("interop_managed")),
+		rpc.WithRPCRecorder(m.NewRecorder("interop_indexing")),
 	)
 	out.srv.AddAPI(gethrpc.API{
 		Namespace:     "interop",
@@ -81,7 +81,7 @@ func NewManagedMode(log log.Logger, cfg *rollup.Config, addr string, port int, j
 	return out
 }
 
-func (m *ManagedMode) Start(ctx context.Context) error {
+func (m *IndexingMode) Start(ctx context.Context) error {
 	if m.emitter == nil {
 		return errors.New("must have emitter before starting")
 	}
@@ -92,19 +92,19 @@ func (m *ManagedMode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (m *ManagedMode) WSEndpoint() string {
+func (m *IndexingMode) WSEndpoint() string {
 	return fmt.Sprintf("ws://%s", m.srv.Endpoint())
 }
 
-func (m *ManagedMode) WSPort() (int, error) {
+func (m *IndexingMode) WSPort() (int, error) {
 	return m.srv.Port()
 }
 
-func (m *ManagedMode) JWTSecret() eth.Bytes32 {
+func (m *IndexingMode) JWTSecret() eth.Bytes32 {
 	return m.jwtSecret
 }
 
-func (m *ManagedMode) Stop(ctx context.Context) error {
+func (m *IndexingMode) Stop(ctx context.Context) error {
 	// stop RPC server
 	if err := m.srv.Stop(); err != nil {
 		return fmt.Errorf("failed to stop interop sub-system RPC server: %w", err)
@@ -114,12 +114,12 @@ func (m *ManagedMode) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (m *ManagedMode) AttachEmitter(em event.Emitter) {
+func (m *IndexingMode) AttachEmitter(em event.Emitter) {
 	m.emitter = em
 }
 
 // Outgoing events to supervisor
-func (m *ManagedMode) OnEvent(ev event.Event) bool {
+func (m *IndexingMode) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
 	case rollup.ResetEvent:
 		msg := x.Err.Error()
@@ -177,15 +177,15 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 	return true
 }
 
-func (m *ManagedMode) PullEvent() (*supervisortypes.ManagedEvent, error) {
+func (m *IndexingMode) PullEvent() (*supervisortypes.ManagedEvent, error) {
 	return m.events.Serve()
 }
 
-func (m *ManagedMode) Events(ctx context.Context) (*gethrpc.Subscription, error) {
+func (m *IndexingMode) Events(ctx context.Context) (*gethrpc.Subscription, error) {
 	return m.events.Subscribe(ctx)
 }
 
-func (m *ManagedMode) UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) error {
+func (m *IndexingMode) UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) error {
 	l2Ref, err := m.l2.L2BlockRefByHash(ctx, id.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to get L2BlockRef: %w", err)
@@ -198,7 +198,7 @@ func (m *ManagedMode) UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) err
 	return nil
 }
 
-func (m *ManagedMode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error {
+func (m *IndexingMode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error {
 	l2Ref, err := m.l2.L2BlockRefByHash(ctx, derived.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to get L2BlockRef: %w", err)
@@ -216,7 +216,7 @@ func (m *ManagedMode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, 
 	return nil
 }
 
-func (m *ManagedMode) UpdateFinalized(ctx context.Context, id eth.BlockID) error {
+func (m *IndexingMode) UpdateFinalized(ctx context.Context, id eth.BlockID) error {
 	l2Ref, err := m.l2.L2BlockRefByHash(ctx, id.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to get L2BlockRef: %w", err)
@@ -227,7 +227,7 @@ func (m *ManagedMode) UpdateFinalized(ctx context.Context, id eth.BlockID) error
 	return nil
 }
 
-func (m *ManagedMode) InvalidateBlock(ctx context.Context, seal supervisortypes.BlockSeal) error {
+func (m *IndexingMode) InvalidateBlock(ctx context.Context, seal supervisortypes.BlockSeal) error {
 	m.log.Info("Invalidating block", "block", seal)
 
 	// Fetch the block we invalidate, so we can re-use the attributes that stay.
@@ -257,7 +257,7 @@ func (m *ManagedMode) InvalidateBlock(ctx context.Context, seal supervisortypes.
 	return nil
 }
 
-func (m *ManagedMode) AnchorPoint(ctx context.Context) (supervisortypes.DerivedBlockRefPair, error) {
+func (m *IndexingMode) AnchorPoint(ctx context.Context) (supervisortypes.DerivedBlockRefPair, error) {
 	// TODO: maybe cache non-genesis anchor point when seeing safe Interop activation block?
 	//  Only needed if we don't test for activation block in the supervisor.
 	if !m.cfg.IsInterop(m.cfg.Genesis.L2Time) {
@@ -289,13 +289,13 @@ const (
 )
 
 // TODO: add ResetPreInterop, called by supervisor if bisection went pre-Interop. Emit ResetEngineRequestEvent.
-func (m *ManagedMode) ResetPreInterop(ctx context.Context) error {
+func (m *IndexingMode) ResetPreInterop(ctx context.Context) error {
 	m.log.Info("Received pre-interop reset request")
 	m.emitter.Emit(engine.ResetEngineRequestEvent{})
 	return nil
 }
 
-func (m *ManagedMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID) error {
+func (m *IndexingMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID) error {
 	logger := m.log.New(
 		"localUnsafe", lUnsafe,
 		"crossUnsafe", xUnsafe,
@@ -381,7 +381,7 @@ func (m *ManagedMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe,
 
 // findLatestValidLocalUnsafe searches and returns the latest valid block of the L2 chain
 // starting from `l2UnsafeTarget` and checking until the latest unsafe block.
-func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
+func (m *IndexingMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
 	latestUnsafe, err := m.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		return eth.L2BlockRef{}, err
@@ -444,7 +444,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 }
 
 // verifyBlock
-func (m *ManagedMode) verifyBlock(ctx context.Context, logger log.Logger, blockNum uint64) (eth.L2BlockRef, error) {
+func (m *IndexingMode) verifyBlock(ctx context.Context, logger log.Logger, blockNum uint64) (eth.L2BlockRef, error) {
 	current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 	if err != nil {
 		return eth.L2BlockRef{}, err
@@ -463,7 +463,7 @@ func (m *ManagedMode) verifyBlock(ctx context.Context, logger log.Logger, blockN
 	return current, nil
 }
 
-func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {
+func (m *IndexingMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {
 	m.log.Info("Received next L1 block", "nextL1", nextL1)
 	m.emitter.Emit(derive.ProvideL1Traversal{
 		NextL1: nextL1,
@@ -471,20 +471,20 @@ func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error 
 	return nil
 }
 
-func (m *ManagedMode) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
+func (m *IndexingMode) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
 	_, receipts, err := m.l2.FetchReceipts(ctx, blockHash)
 	return receipts, err
 }
 
-func (m *ManagedMode) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
+func (m *IndexingMode) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
 	return m.l2.BlockRefByNumber(ctx, num)
 }
 
-func (m *ManagedMode) ChainID(ctx context.Context) (eth.ChainID, error) {
+func (m *IndexingMode) ChainID(ctx context.Context) (eth.ChainID, error) {
 	return eth.ChainIDFromBig(m.cfg.L2ChainID), nil
 }
 
-func (m *ManagedMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+func (m *IndexingMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
 	ref, err := m.L2BlockRefByTimestamp(ctx, timestamp)
 	if err != nil {
 		return nil, err
@@ -492,7 +492,7 @@ func (m *ManagedMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64)
 	return m.l2.OutputV0AtBlock(ctx, ref.Hash)
 }
 
-func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+func (m *IndexingMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
 	ref, err := m.L2BlockRefByTimestamp(ctx, timestamp)
 	if err != nil {
 		return nil, err
@@ -516,7 +516,7 @@ func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp 
 	return optimisticOutput, nil
 }
 
-func (m *ManagedMode) L2BlockRefByTimestamp(ctx context.Context, timestamp uint64) (eth.L2BlockRef, error) {
+func (m *IndexingMode) L2BlockRefByTimestamp(ctx context.Context, timestamp uint64) (eth.L2BlockRef, error) {
 	num, err := m.cfg.TargetBlockNumber(timestamp)
 	if err != nil {
 		return eth.L2BlockRef{}, err

--- a/op-node/rollup/interop/indexing/system_test.go
+++ b/op-node/rollup/interop/indexing/system_test.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
-func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
+func TestIndexingMode_findLatestValidLocalUnsafe(t *testing.T) {
 	tests := []struct {
 		name           string
 		l2Unsafe       uint64   // starting point (trusted valid)
@@ -147,13 +147,13 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 				}
 			}
 
-			managedMode := &ManagedMode{
+			indexingMode := &IndexingMode{
 				log: logger,
 				l1:  mockL1,
 				l2:  mockL2,
 			}
 
-			result, err := managedMode.findLatestValidLocalUnsafe(ctx, eth.BlockID{
+			result, err := indexingMode.findLatestValidLocalUnsafe(ctx, eth.BlockID{
 				Hash:   l2UnsafeHash,
 				Number: tt.l2Unsafe,
 			})

--- a/op-program/client/tasks/deposits_block.go
+++ b/op-program/client/tasks/deposits_block.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"

--- a/op-program/client/tasks/deposits_block.go
+++ b/op-program/client/tasks/deposits_block.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
+       "github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
@@ -128,7 +128,7 @@ func blockToDepositsOnlyAttributes(cfg *rollup.Config, block *types.Block, outpu
 			deposits = append(deposits, txdata)
 		}
 	}
-	invalidatedBlockTx := managed.InvalidatedBlockSourceDepositTx(output.Marshal())
+       invalidatedBlockTx := indexing.InvalidatedBlockSourceDepositTx(output.Marshal())
 	invalidatedBlockTxData, err := invalidatedBlockTx.MarshalBinary()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal deposited tx: %w", err)

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -98,12 +98,12 @@ flowchart TD
 
 Op-nodes, or any compatible consensus-layer L2 node can interact with op-supervisor in two modes:
 
-#### Managed Mode
+#### Indexing Mode
 
-In managed mode, nodes cede control over aspects of the derivation process to the supervisor, which maintains the node's sync status.
+In indexing mode, nodes cede control over aspects of the derivation process to the supervisor, which maintains the node's sync status.
 This is done to give the supervisor a clear picture of the data across multiple chains, and to ensure the supervisor can recover/reset as needed.
 
-Managed nodes can be thought of integral to the supervisor. There must be *at least* one managed node per chain connected
+Indexing nodes can be thought of integral to the supervisor. There must be *at least* one indexing node per chain connected
 to a supervisor for it to supply accurate data.
 
 The Supervisor subscribes to events from the op-node in order to react appropriately.
@@ -123,17 +123,17 @@ Additionally, the supervisor sends control signals to the op-node triggered by *
 | New cross-safe head  | Supervisor sends the head to the node, where it is recorded as the cross-safe head |
 | New finalized head  | Supervisor sends the head to the node, where it is recorded as the finalized head |
 
-Nodes in managed mode *do not* discover their own L1 blocks.
+Nodes in indexing mode *do not* discover their own L1 blocks.
 Instead, the supervisor watches the L1 and sends the block hash to the node, which is used instead of L1 traversal.
-In this way, all managed nodes are guaranteed to share the same L1 chain, and their data can be aggregated consistently.
+In this way, all indexing nodes are guaranteed to share the same L1 chain, and their data can be aggregated consistently.
 
-#### Standard Mode
-(Standard mode is in development)
+#### Following Mode
+(Following mode is in development)
 
-In standard mode, an `op-node` continues to handle derivation and L1 discovery as it would without a supervisor.
-However, it calls out to the supervisor periodically to update its cross-heads. Standard nodes do not affect the supervisor's data in any way.
+In following mode, an `op-node` continues to handle derivation and L1 discovery as it would without a supervisor.
+However, it calls out to the supervisor periodically to update its cross-heads. Following nodes do not affect the supervisor's data in any way.
 
-In this way, standard nodes can optimistically follow cross-safety without requiring the larger infrastructure of multiple nodes and a supervisor.
+In this way, following nodes can optimistically follow cross-safety without requiring the larger infrastructure of multiple nodes and a supervisor.
 
 ### Data Flow Visualization
 
@@ -143,7 +143,7 @@ sequenceDiagram
 autonumber
 
 participant super as op-supervisor
-participant node as op-node (managed)
+participant node as op-node (indexing)
 participant geth as op-geth
 
 super ->> node: RPC connection established
@@ -169,7 +169,7 @@ sequenceDiagram
 autonumber
 
 participant super as op-supervisor
-participant node as op-node (managed)
+participant node as op-node (indexing)
 participant p2p as p2p
 
 p2p ->> node: New unsafe block from gossip network

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
 

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -169,7 +169,7 @@ func (rs *RPCSyncNode) AnchorPoint(ctx context.Context) (types.DerivedBlockRefPa
 	)
 	err := rs.cl.CallContext(ctx, &out, "interop_anchorPoint")
 	// Translate an interop-inactive error into a ErrFuture.
-	if errors.As(err, &jsonErr) && jsonErr.ErrorCode() == managed.InteropInactiveRPCErrCode {
+       if errors.As(err, &jsonErr) && jsonErr.ErrorCode() == indexing.InteropInactiveRPCErrCode {
 		return types.DerivedBlockRefPair{}, types.ErrFuture
 	}
 	return out, err


### PR DESCRIPTION
## Summary
- rename managed mode to indexing mode across docs and code
- update `op-node` interop package and imports
- rename driver fields and variables
- adjust devstack and tests for new naming

