### PR TITLE
Add memory usage metric to op-batcher

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -75,6 +75,7 @@ type BatcherService struct {
 	rpcServer    *oprpc.Server
 
 	balanceMetricer io.Closer
+	memoryMetricer  io.Closer
 	stopped         atomic.Bool
 
 	NotSubmittingOnStart bool
@@ -178,6 +179,7 @@ func (bs *BatcherService) initMetrics(cfg *CLIConfig) {
 	if cfg.MetricsConfig.Enabled {
 		procName := "default"
 		bs.Metrics = metrics.NewMetrics(procName)
+		bs.memoryMetricer = bs.Metrics.StartMemoryMetrics(bs.Log)
 	} else {
 		bs.Metrics = metrics.NoopMetrics
 	}
@@ -446,6 +448,11 @@ func (bs *BatcherService) Stop(ctx context.Context) error {
 	if bs.balanceMetricer != nil {
 		if err := bs.balanceMetricer.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
+		}
+	}
+	if bs.memoryMetricer != nil {
+		if err := bs.memoryMetricer.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close memory metricer: %w", err))
 		}
 	}
 

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -32,6 +32,7 @@ type Metricer interface {
 	opmetrics.RPCMetricer
 
 	StartBalanceMetrics(l log.Logger, client *ethclient.Client, account common.Address) io.Closer
+	StartMemoryMetrics(l log.Logger) io.Closer
 
 	RecordLatestL1Block(l1ref eth.L1BlockRef)
 	RecordL2BlocksLoaded(l2ref eth.L2BlockRef)
@@ -96,6 +97,8 @@ type Metrics struct {
 	batcherTxEvs opmetrics.EventVec
 
 	blobUsedBytes prometheus.Histogram
+
+	memoryAllocBytes prometheus.Gauge
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -209,6 +212,12 @@ func NewMetrics(procName string) *Metrics {
 			Buckets:   prometheus.LinearBuckets(0.0, eth.MaxBlobDataSize/13, 14),
 		}),
 
+		memoryAllocBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "memory_alloc_bytes",
+			Help:      "Number of bytes allocated and still in use by the go runtime.",
+		}),
+
 		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),
 	}
 	m.pendingDABytesGaugeFunc = factory.NewGaugeFunc(prometheus.GaugeOpts{
@@ -236,6 +245,10 @@ func (m *Metrics) PendingDABytes() float64 {
 
 func (m *Metrics) StartBalanceMetrics(l log.Logger, client *ethclient.Client, account common.Address) io.Closer {
 	return opmetrics.LaunchBalanceMetrics(l, m.registry, m.ns, client, account)
+}
+
+func (m *Metrics) StartMemoryMetrics(l log.Logger) io.Closer {
+	return opmetrics.LaunchMemoryMetrics(l, m.registry, m.ns, m.memoryAllocBytes)
 }
 
 // RecordInfo sets a pseudo-metric that contains versioning and

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -48,6 +48,9 @@ func (*noopMetrics) RecordBlobUsedBytes(int) {}
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }
+func (*noopMetrics) StartMemoryMetrics(log.Logger) io.Closer {
+	return nil
+}
 func (nm *noopMetrics) PendingDABytes() float64 {
 	return 0.0
 }

--- a/op-batcher/metrics/test.go
+++ b/op-batcher/metrics/test.go
@@ -1,7 +1,10 @@
 package metrics
 
 import (
+	"io"
+
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type TestMetrics struct {
@@ -34,3 +37,5 @@ func (m *TestMetrics) ClearAllStateMetrics() {
 	m.ChannelQueueLength = 0
 	m.pendingDABytes = 0
 }
+
+func (m *TestMetrics) StartMemoryMetrics(log.Logger) io.Closer { return nil }

--- a/op-service/metrics/memory.go
+++ b/op-service/metrics/memory.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+)
+
+// LaunchMemoryMetrics starts a periodic collection of Go runtime memory stats
+// and records the allocated heap bytes into the provided gauge. The gauge is
+// expected to have Help text describing the metric. The returned closer stops
+// the background loop.
+func LaunchMemoryMetrics(log log.Logger, r *prometheus.Registry, ns string, g prometheus.Gauge) *clock.LoopFn {
+	if g == nil {
+		g = promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "memory_alloc_bytes",
+			Help:      "Number of bytes allocated and still in use by the go runtime.",
+		})
+	}
+	return clock.NewLoopFn(clock.SystemClock, func(ctx context.Context) {
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		g.Set(float64(ms.Alloc))
+	}, func() error {
+		log.Info("memory metrics shutting down")
+		return nil
+	}, 10*time.Second)
+}


### PR DESCRIPTION
## Summary
- add a runtime memory gauge to op-batcher metrics
- periodically collect memory stats via LaunchMemoryMetrics
- start memory metrics in initMetrics

## Testing
- `go test ./op-batcher/...`
- `go test ./...` *(fails: missing test data)*


------
https://chatgpt.com/codex/tasks/task_e_685bf43e0ccc832285ccfabf92ac6291